### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![image](https://dl.dropboxusercontent.com/s/em253abjckwr6k4/Virtuoso.png)
 
-#Laravel Virtuoso
+# Laravel Virtuoso
 
-####Laravel Composable View Composers Package
+#### Laravel Composable View Composers Package
 
 Increase flexibility and reduce code duplication by easily composing complex View Composers from simple 
 component Composers without unnecessary indirection or boilerplate code.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
